### PR TITLE
시작옵션 파일 적용문제 수정

### DIFF
--- a/PUBG_InterruptTimeControl/Components/Function/Danger/StartOptionProgram.xaml.cs
+++ b/PUBG_InterruptTimeControl/Components/Function/Danger/StartOptionProgram.xaml.cs
@@ -110,6 +110,11 @@ namespace PUBG_InterruptTimeControl.Components.Function.Danger
 
             try
             {
+                var movePath = regServerPath + @"\TslGame_BE2.exe";
+
+                //이미 기존 원본파일명이 변경되어있는 파일이 있는 경우 제거.
+                if (File.Exists(movePath))
+                    File.Delete(movePath);
                 //기존 원본파일 파일명 변경
                 File.Move(bePath, regServerPath + @"\TslGame_BE2.exe");
                 // 시작옵션 프로그램 복사

--- a/PUBG_InterruptTimeControl/PUBG_InterruptTimeControl.csproj
+++ b/PUBG_InterruptTimeControl/PUBG_InterruptTimeControl.csproj
@@ -171,12 +171,12 @@
       <SubType>Designer</SubType>
     </Page>
     <Page Include="Components\Function\Danger\DatChange.xaml">
-      <Generator>MSBuild:Compile</Generator>
       <SubType>Designer</SubType>
+      <Generator>XamlIntelliSenseFileGenerator</Generator>
     </Page>
     <Page Include="Components\Function\Danger\FileEngine.xaml">
-      <Generator>MSBuild:Compile</Generator>
       <SubType>Designer</SubType>
+      <Generator>XamlIntelliSenseFileGenerator</Generator>
     </Page>
     <Page Include="Components\Function\Danger\StartOptionProgram.xaml">
       <SubType>Designer</SubType>


### PR DESCRIPTION
파일 꼬임으로 인해서 이미 이름을 바꾸려는 파일이 있을 경우 적용 실패하는 부분이 있어 이름을 바꾸기 전 파일을 체크하여 있으면 지운 후에 파일의 이름을 변경할 수 있도록 변경.